### PR TITLE
Fix missing 'python-software-properties'

### DIFF
--- a/storm-nimbus/Dockerfile
+++ b/storm-nimbus/Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu
 
 RUN apt-get update && \
     apt-get install -y build-essential && \
-    apt-get install -y software-properties-common python-software-properties && \
+    apt-get install -y software-properties-common && \
     apt-get install -y python
 
 # Install Java.

--- a/storm-supervisor/Dockerfile
+++ b/storm-supervisor/Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu
 
 RUN apt-get update && \
     apt-get install -y build-essential && \
-    apt-get install -y software-properties-common python-software-properties && \
+    apt-get install -y software-properties-common && \
     apt-get install -y python
 
 # Install Java.


### PR DESCRIPTION
Solves problem on fresh `docker-compose up`:
E: Package 'python-software-properties' has no installation candidate